### PR TITLE
Fix API handlers to support GET

### DIFF
--- a/pages/api/gs1/track.js
+++ b/pages/api/gs1/track.js
@@ -1,4 +1,4 @@
 export default function handler(req, res) {
-  const { gs1 } = req.body;
+  const gs1 = req.method === "POST" ? req.body.gs1 : req.query.gs1;
   res.status(200).json({ gs1, product: "GOAT Merch", royalties: "$1,223" });
 }

--- a/pages/api/isrc/validate.js
+++ b/pages/api/isrc/validate.js
@@ -1,4 +1,4 @@
 export default function handler(req, res) {
-  const { isrc } = req.body;
+  const isrc = req.method === "POST" ? req.body.isrc : req.query.isrc;
   res.status(200).json({ isrc, match: true, source: "ISRC Registry" });
 }


### PR DESCRIPTION
## Summary
- handle query parameters in GS1/ISRC API handlers

## Testing
- `npm test` *(fails: Missing script 'test')*